### PR TITLE
feat(telegram): include message content with tool calls in draft

### DIFF
--- a/internal/agent/progress.go
+++ b/internal/agent/progress.go
@@ -14,5 +14,5 @@ type LLMStartInfo struct {
 type ProgressObserver interface {
 	OnLLMStart(ctx context.Context, info LLMStartInfo)
 	OnLLMStreamDelta(ctx context.Context, delta string)
-	OnToolCalls(ctx context.Context, calls []llm.ToolCall)
+	OnToolCalls(ctx context.Context, calls []llm.ToolCall, content string)
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -183,7 +183,7 @@ func (s *Session) runLoop(ctx context.Context, userID int64, messages []llm.Mess
 
 		log.Debug("tool calls received", zap.Int("count", len(msg.ToolCalls)), zap.Int64("session_id", s.id))
 		if observer != nil {
-			observer.OnToolCalls(ctx, msg.ToolCalls)
+			observer.OnToolCalls(ctx, msg.ToolCalls, msg.Content)
 		}
 		if err := s.deps.store.AddMessage(ctx, s.id, "assistant", msg.Content, &memory.MessageMetadata{ToolCalls: msg.ToolCalls}); err != nil {
 			return "", err

--- a/internal/server/telegram_progress.go
+++ b/internal/server/telegram_progress.go
@@ -113,13 +113,19 @@ func (p *telegramProgress) OnLLMStreamDelta(ctx context.Context, delta string) {
 	p.draftRetryUntil = time.Time{}
 }
 
-func (p *telegramProgress) OnToolCalls(ctx context.Context, calls []llm.ToolCall) {
+
+func (p *telegramProgress) OnToolCalls(ctx context.Context, calls []llm.ToolCall, content string) {
 	if p == nil || len(calls) == 0 {
 		return
 	}
-	text := formatToolCalls(calls)
-	if text == "" {
+	toolText := formatToolCalls(calls)
+	if toolText == "" {
 		return
+	}
+	// Prepend message content if present
+	text := toolText
+	if content = strings.TrimSpace(content); content != "" {
+		text = content + "\n\n" + toolText
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
## Problem

When the LLM returns tool calls, the Telegram draft only shows the tool call list (e.g., "Running tools: - read_file"). If the LLM also returns message content (thinking/explanation), it was not shown to the user.

## Solution

Modified `OnToolCalls` to accept and display the message content alongside tool calls.

**Before:**
```
Running tools:
- read_file file_path=/app/config.toml
```

**After:**
```
Let me check the configuration file first.

Running tools:
- read_file file_path=/app/config.toml
```

## Changes

- `internal/agent/progress.go`: Add `content string` parameter to `OnToolCalls` interface
- `internal/agent/session.go`: Pass `msg.Content` to `OnToolCalls`
- `internal/server/telegram_progress.go`: Prepend content to tool call text if present

## Testing

- Code compiles successfully
- If content is empty, behavior is unchanged (backward compatible)