### PR TITLE
Add common tools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,26 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /agentd ./cmd/agentd
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install ca-certificates for HTTPS connections and timezone data
+# Install common tools that are frequently needed
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     tzdata \
     sudo \
+    # Version control
+    git \
+    # Network tools
+    curl \
+    wget \
+    # Text processing
+    ripgrep \
+    # File utilities
+    file \
+    # Archive utilities
+    unzip \
+    # Process utilities
+    procps \
+    # GitHub CLI
+    gh \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
Pre-install frequently used tools to avoid reinstalling on each container restart.

## Added Tools

| Tool | Purpose |
|------|---------|
| git | Version control |
| curl, wget | Network requests |
| ripgrep | Fast text search (rg) |
| file | File type detection |
| unzip | Archive extraction |
| procps | Process utilities (ps, top, etc.) |
| gh | GitHub CLI |

These tools are commonly needed during development and debugging sessions.