### PR TITLE
Add session interruption for Telegram

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -155,6 +155,15 @@ func (a *Agent) SetSessionWaitingForApproval(sessionID int64, message string) {
 	}
 }
 
+// CancelSession cancels any ongoing operation for the session.
+// Returns true if there was an operation to cancel.
+func (a *Agent) CancelSession(sessionID int64) bool {
+	if a == nil || a.sessions == nil {
+		return false
+	}
+	return a.sessions.Cancel(sessionID)
+}
+
 func toLLMMessages(msgs []memory.Message) []llm.Message {
 	out := make([]llm.Message, 0, len(msgs))
 	for _, m := range msgs {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -17,6 +17,10 @@ type Session struct {
 	refs int
 	deps *sessionDeps
 	mu   sync.Mutex
+
+	// For session interruption
+	cancelMu   sync.Mutex
+	cancelFunc context.CancelFunc
 }
 
 func (s *Session) setState(state SessionState) {
@@ -37,6 +41,29 @@ func (s *Session) setWaitingForApproval(message string) {
 	}
 }
 
+func (s *Session) setCancelFunc(cancel context.CancelFunc) {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	s.cancelFunc = cancel
+}
+
+func (s *Session) clearCancelFunc() {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	s.cancelFunc = nil
+}
+
+func (s *Session) cancel() bool {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if s.cancelFunc != nil {
+		s.cancelFunc()
+		s.cancelFunc = nil
+		return true
+	}
+	return false
+}
+
 func (s *Session) Handle(ctx context.Context, userID int64, channel string, input string, modelOverride string, observer ProgressObserver) (string, error) {
 	if s == nil || s.deps == nil {
 		return "", errors.New("session not configured")
@@ -49,6 +76,15 @@ func (s *Session) Handle(ctx context.Context, userID int64, channel string, inpu
 	if modelOverride != "" {
 		model = modelOverride
 	}
+
+	// Create a cancellable context for this session operation
+	ctx, cancel := context.WithCancel(ctx)
+	s.setCancelFunc(cancel)
+	defer func() {
+		s.clearCancelFunc()
+		cancel()
+	}()
+
 	s.setState(StateWaitingForLLM)
 	s.deps.stateManager.SetLLMModel(s.id, model)
 	defer s.setState(StateIdle)

--- a/internal/agent/session_manager.go
+++ b/internal/agent/session_manager.go
@@ -70,3 +70,18 @@ func (m *sessionManager) Release(sessionID int64) {
 		delete(m.sessions, sessionID)
 	}
 }
+
+// Cancel cancels any ongoing operation for the session.
+// It returns true if there was an active operation to cancel.
+func (m *sessionManager) Cancel(sessionID int64) bool {
+	if m == nil || sessionID == 0 {
+		return false
+	}
+	m.mu.Lock()
+	session := m.sessions[sessionID]
+	m.mu.Unlock()
+	if session == nil {
+		return false
+	}
+	return session.cancel()
+}

--- a/internal/server/telegram.go
+++ b/internal/server/telegram.go
@@ -65,6 +65,12 @@ func (s *Server) handleTelegramUpdate(ctx context.Context, b *bot.Bot, update *m
 	if s.handleTelegramCommand(ctx, b, update, uid, sessionID) {
 		return
 	}
+
+	// Cancel any previous operation for this session
+	if s.agent.CancelSession(sessionID) {
+		log.Info("cancelled previous session operation", zap.Int64("session_id", sessionID))
+	}
+
 	threadID := update.Message.MessageThreadID
 	businessConnID := update.Message.BusinessConnectionID
 	directTopicID := 0


### PR DESCRIPTION
When a new Telegram message arrives, cancel any ongoing operation for that session before starting the new one.

## Features

- **Interrupt LLM calls**: If LLM is generating a response, it will be cancelled
- **Interrupt tool execution**: If a tool is running, it will be cancelled  
- **Immediate response**: New message starts processing right after interruption

## Implementation

1. Add `cancelFunc` tracking in `Session` struct
2. Create cancellable context in `Session.Handle` using `context.WithCancel`
3. Add `CancelSession` method to `Agent`
4. Call `CancelSession` in `handleTelegramUpdate` before starting new operation

## Usage

Just send a new message on Telegram while a previous operation is running. The previous operation will be cancelled and the new message will be processed immediately.