### PR TITLE
Clear draft before sending final message

### DIFF
--- a/internal/server/telegram.go
+++ b/internal/server/telegram.go
@@ -90,6 +90,8 @@ func (s *Server) handleTelegramUpdate(ctx context.Context, b *bot.Bot, update *m
 		log.Error("telegram agent error", zap.Error(err))
 		return
 	}
+	// Clear draft before sending the final message to avoid simultaneous display
+	progress.ClearDraft(ctx)
 	for _, chunk := range splitTelegramMessage(output) {
 		params := &bot.SendMessageParams{
 			ChatID:    update.Message.Chat.ID,

--- a/internal/server/telegram_progress.go
+++ b/internal/server/telegram_progress.go
@@ -147,6 +147,33 @@ func (p *telegramProgress) OnToolCalls(ctx context.Context, calls []llm.ToolCall
 	}
 }
 
+// ClearDraft clears the draft message by sending an empty draft with the same draftId.
+// This should be called before sending the final message to avoid the draft being displayed
+// simultaneously with the final message.
+func (p *telegramProgress) ClearDraft(ctx context.Context) {
+	if p == nil || p.bot == nil {
+		return
+	}
+	p.mu.Lock()
+	baseID := p.streamBaseID
+	p.mu.Unlock()
+	if baseID == 0 {
+		return
+	}
+	params := &bot.SendMessageDraftParams{
+		ChatID:  p.chatID,
+		DraftID: strconv.FormatInt(baseID+1, 10),
+		Text:    "",
+	}
+	if p.threadID > 0 {
+		params.MessageThreadID = p.threadID
+	}
+	if p.businessConnectionID != "" {
+		params.BusinessConnectionID = p.businessConnectionID
+	}
+	_, _ = p.bot.SendMessageDraft(ctx, params)
+}
+
 func (p *telegramProgress) ensureTyping(ctx context.Context) {
 	if p == nil || p.bot == nil {
 		return


### PR DESCRIPTION
## Problem

When using `sendMessageDraft` for streaming preview, the draft message may appear simultaneously with the final message sent via `sendMessage`. This is because Telegram Bot API's `sendMessageDraft` does not automatically clear the draft when a regular message is sent.

## Solution

Clear the draft by sending an empty draft with the same `draftId` before sending the final message. This is the same pattern used in OpenClaw's `draft-stream.ts` `materialize` function.

## Changes

- Add `ClearDraft` method to `telegramProgress` that sends an empty draft
- Call `progress.ClearDraft(ctx)` before sending final messages in `handleTelegramUpdate`

## Testing

Tested manually: the draft preview now disappears when the final message is sent.