### PR TITLE
feat: add Guidelines feature for bot behavioral rules

### DIFF
--- a/cmd/agentd/main.go
+++ b/cmd/agentd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/YangKeao/haro-bot/internal/config"
 	"github.com/YangKeao/haro-bot/internal/db"
 	"github.com/YangKeao/haro-bot/internal/fork"
+	"github.com/YangKeao/haro-bot/internal/guidelines"
 	"github.com/YangKeao/haro-bot/internal/llm"
 	"github.com/YangKeao/haro-bot/internal/logging"
 	"github.com/YangKeao/haro-bot/internal/memory"
@@ -64,6 +65,7 @@ func main() {
 	store := memory.NewStore(dbConn)
 	skillsStore := skills.NewStore(dbConn)
 	skillsMgr := skills.NewManager(skillsStore, cfg.SkillsDir, cfg.SkillsRepoAllowlist)
+	guidelinesMgr := guidelines.NewManager(dbConn)
 
 	if *unrestricted {
 		log.Warn("running in UNRESTRICTED mode - path restrictions and symlink checks are disabled!")
@@ -92,6 +94,7 @@ func main() {
 		tools.NewListDirTool(fsTools),
 		tools.NewExecCommandTool(fsTools, execMgr),
 		tools.NewWriteStdinTool(execMgr),
+		tools.NewUpdateGuidelinesTool(guidelinesMgr),
 	)
 	llmClient := llm.NewClient(cfg.LLMBaseURL, cfg.LLMAPIKey, llm.WithHTTPDebug(cfg.LLMHTTPDebug))
 	contextCfg := llm.ContextConfig{
@@ -109,6 +112,7 @@ func main() {
 		memoryEngine,
 		skillsMgr,
 		toolRegistry,
+		guidelinesMgr,
 		fsTools.DefaultBase(),
 		cfg.ToolMaxTurns,
 		llmClient,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/YangKeao/haro-bot/internal/guidelines"
 	"github.com/YangKeao/haro-bot/internal/llm"
 	"github.com/YangKeao/haro-bot/internal/logging"
 	"github.com/YangKeao/haro-bot/internal/memory"
@@ -33,11 +34,11 @@ type Agent struct {
 	messenger      SessionMessenger
 }
 
-func New(store memory.StoreAPI, memoryEngine *memory.Engine, skills *skills.Manager, toolRegistry *tools.Registry, defaultBaseDir string, maxToolTurns int, llmClient *llm.Client, model string, promptFormat string, reasoning llm.ReasoningConfig, contextConfig llm.ContextConfig) *Agent {
+func New(store memory.StoreAPI, memoryEngine *memory.Engine, skills *skills.Manager, toolRegistry *tools.Registry, guidelinesMgr *guidelines.Manager, defaultBaseDir string, maxToolTurns int, llmClient *llm.Client, model string, promptFormat string, reasoning llm.ReasoningConfig, contextConfig llm.ContextConfig) *Agent {
 	if maxToolTurns <= 0 {
 		maxToolTurns = 1024
 	}
-	promptBuilder := DefaultPromptBuilder{}
+	promptBuilder := NewDefaultPromptBuilder(guidelinesMgr)
 	toolRunner := NewToolRunner(toolRegistry, store, skills, promptBuilder)
 	estimator, _ := llm.NewTokenEstimator(model)
 	stateMgr := newSessionStateManager()

--- a/internal/agent/interfaces.go
+++ b/internal/agent/interfaces.go
@@ -13,8 +13,8 @@ import (
 type ConversationStore = memory.StoreAPI
 
 type PromptBuilder interface {
-	System(memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string
-	Interrupt(memories []memory.MemoryItem, format string) string
+	System(ctx context.Context, memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string
+	Interrupt(ctx context.Context, memories []memory.MemoryItem, format string) string
 	Skill(skill skills.Skill) string
 }
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -1,37 +1,50 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 
+	"github.com/YangKeao/haro-bot/internal/guidelines"
 	"github.com/YangKeao/haro-bot/internal/memory"
 	"github.com/YangKeao/haro-bot/internal/skills"
 )
 
-func buildSystemPrompt(memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string {
-	return buildPrompt(memories, skillsList, format, true)
+// GuidelinesLoader fetches active guidelines for prompt building
+type GuidelinesLoader interface {
+	GetActive(ctx context.Context) (*guidelines.Guidelines, error)
 }
 
-func buildInterruptPrompt(memories []memory.MemoryItem, format string) string {
-	return buildPrompt(memories, nil, format, false)
+func buildSystemPrompt(ctx context.Context, gl GuidelinesLoader, memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string {
+	return buildPrompt(ctx, gl, memories, skillsList, format, true)
 }
 
-type DefaultPromptBuilder struct{}
-
-func (DefaultPromptBuilder) System(memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string {
-	return buildSystemPrompt(memories, skillsList, format)
+func buildInterruptPrompt(ctx context.Context, gl GuidelinesLoader, memories []memory.MemoryItem, format string) string {
+	return buildPrompt(ctx, gl, memories, nil, format, false)
 }
 
-func (DefaultPromptBuilder) Interrupt(memories []memory.MemoryItem, format string) string {
-	return buildInterruptPrompt(memories, format)
+type DefaultPromptBuilder struct {
+	gl GuidelinesLoader
 }
 
-func (DefaultPromptBuilder) Skill(skill skills.Skill) string {
+func NewDefaultPromptBuilder(gl GuidelinesLoader) *DefaultPromptBuilder {
+	return &DefaultPromptBuilder{gl: gl}
+}
+
+func (b *DefaultPromptBuilder) System(ctx context.Context, memories []memory.MemoryItem, skillsList []skills.Metadata, format string) string {
+	return buildSystemPrompt(ctx, b.gl, memories, skillsList, format)
+}
+
+func (b *DefaultPromptBuilder) Interrupt(ctx context.Context, memories []memory.MemoryItem, format string) string {
+	return buildInterruptPrompt(ctx, b.gl, memories, format)
+}
+
+func (b *DefaultPromptBuilder) Skill(skill skills.Skill) string {
 	return buildSkillPrompt(skill)
 }
 
-func buildPrompt(memories []memory.MemoryItem, skillsList []skills.Metadata, format string, includeSkills bool) string {
+func buildPrompt(ctx context.Context, gl GuidelinesLoader, memories []memory.MemoryItem, skillsList []skills.Metadata, format string, includeSkills bool) string {
 	var b strings.Builder
 	format = strings.ToLower(strings.TrimSpace(format))
 	skillsXML := ""
@@ -44,6 +57,16 @@ func buildPrompt(memories []memory.MemoryItem, skillsList []skills.Metadata, for
 	}
 	b.WriteString("You are an assistant. Use the provided long-term memory when relevant.\n")
 	b.WriteString("When the conversation gets long or you need a clean handoff, create a session summary using the session_summary tool with a concise summary and optional state.\n")
+	
+	// Load and include guidelines if available
+	if gl != nil {
+		if g, err := gl.GetActive(ctx); err == nil && g != nil && g.Content != "" {
+			b.WriteString("\n## Guidelines\n")
+			b.WriteString(g.Content)
+			b.WriteString("\n\n")
+		}
+	}
+	
 	if len(memories) > 0 {
 		b.WriteString("Long-term memory:\n")
 		for _, m := range memories {

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -9,13 +10,14 @@ import (
 )
 
 func TestBuildSystemPromptIncludesSkillsAndMemories(t *testing.T) {
+	ctx := context.Background()
 	memories := []memory.MemoryItem{
 		{Type: "note", Content: "remember this"},
 	}
 	skillsList := []skills.Metadata{
 		{Name: "demo", Description: "demo skill", Dir: "/tmp/demo"},
 	}
-	out := buildSystemPrompt(memories, skillsList, "openai")
+	out := buildSystemPrompt(ctx, nil, memories, skillsList, "openai")
 	if !strings.Contains(out, "Long-term memory:") {
 		t.Fatalf("expected memory section, got: %s", out)
 	}
@@ -34,10 +36,11 @@ func TestBuildSystemPromptIncludesSkillsAndMemories(t *testing.T) {
 }
 
 func TestBuildSystemPromptClaudeXML(t *testing.T) {
+	ctx := context.Background()
 	skillsList := []skills.Metadata{
 		{Name: "demo", Description: "demo skill", Dir: "/tmp/demo"},
 	}
-	out := buildSystemPrompt(nil, skillsList, "claude")
+	out := buildSystemPrompt(ctx, nil, nil, skillsList, "claude")
 	if !strings.HasPrefix(out, "<available_skills>") {
 		t.Fatalf("expected XML prefix, got: %s", out)
 	}
@@ -50,10 +53,11 @@ func TestBuildSystemPromptClaudeXML(t *testing.T) {
 }
 
 func TestBuildInterruptPromptNoSkills(t *testing.T) {
+	ctx := context.Background()
 	memories := []memory.MemoryItem{
 		{Type: "note", Content: "remember this"},
 	}
-	out := buildInterruptPrompt(memories, "openai")
+	out := buildInterruptPrompt(ctx, nil, memories, "openai")
 	if !strings.Contains(out, "Long-term memory:") {
 		t.Fatalf("expected memory section, got: %s", out)
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -100,7 +100,7 @@ func (s *Session) Handle(ctx context.Context, userID int64, channel string, inpu
 	if err != nil {
 		return "", err
 	}
-	systemPrompt := s.deps.promptBuilder.System(memories, availableSkills, s.deps.promptFormat)
+	systemPrompt := s.deps.promptBuilder.System(ctx, memories, availableSkills, s.deps.promptFormat)
 	baseMessages := []llm.Message{{Role: "system", Content: systemPrompt}}
 	if summaryMsg := formatSummaryMessage(summary); summaryMsg != "" {
 		baseMessages = append(baseMessages, llm.Message{Role: "system", Content: summaryMsg})
@@ -140,7 +140,7 @@ func (s *Session) Interrupt(ctx context.Context, userID int64, input string, mod
 		}
 	}
 	memories := s.retrieveMemories(ctx, userID, input)
-	systemPrompt := s.deps.promptBuilder.Interrupt(memories, s.deps.promptFormat)
+	systemPrompt := s.deps.promptBuilder.Interrupt(ctx, memories, s.deps.promptFormat)
 	recent, summary, err := s.deps.store.LoadViewMessages(ctx, s.id, 0)
 	if err != nil {
 		return "", err

--- a/internal/agent/tool_runner.go
+++ b/internal/agent/tool_runner.go
@@ -22,7 +22,7 @@ type DefaultToolRunner struct {
 
 func NewToolRunner(registry *tools.Registry, store ConversationStore, skillsMgr *skills.Manager, prompts PromptBuilder) *DefaultToolRunner {
 	if prompts == nil {
-		prompts = DefaultPromptBuilder{}
+		prompts = NewDefaultPromptBuilder(nil)
 	}
 	return &DefaultToolRunner{
 		registry: registry,

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -28,7 +28,7 @@ type migration struct {
 	apply   func(*gorm.DB, config.MemoryConfig) error
 }
 
-const currentSchemaVersion int64 = 9
+const currentSchemaVersion int64 = 10
 
 var migrations = []migration{
 	{version: 1, stmts: initSchemaSQL},
@@ -40,6 +40,7 @@ var migrations = []migration{
 	{version: 7, stmts: renameSessionSummaryIndexesSQL},
 	{version: 8, stmts: replaceMemoriesTableSQL},
 	{version: 9, apply: applyMemoryVectorIndex},
+	{version: 10, stmts: addGuidelinessSQL},
 }
 
 func applyMigrations(db *gorm.DB, memCfg config.MemoryConfig) error {
@@ -351,4 +352,17 @@ func ensureMemoryVectorIndex(db *gorm.DB, distance string) error {
 		return err
 	}
 	return nil
+}
+
+var addGuidelinessSQL = []string{
+	`CREATE TABLE IF NOT EXISTS constitutions (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  content LONGTEXT NOT NULL,
+  version INT NOT NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_constitutions_version (version),
+  INDEX idx_constitutions_active (is_active)
+)`,
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -109,3 +109,16 @@ type AppConfig struct {
 }
 
 func (AppConfig) TableName() string { return "app_config" }
+
+// Guidelines stores the bot's behavioral guidelines and principles.
+// The database table is named "constitutions" for backward compatibility.
+type Guidelines struct {
+	ID        int64     `gorm:"primaryKey;autoIncrement"`
+	Content   string    `gorm:"column:content;type:longtext"`
+	Version   int       `gorm:"column:version"`
+	IsActive  bool      `gorm:"column:is_active"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func (Guidelines) TableName() string { return "constitutions" }

--- a/internal/guidelines/guidelines.go
+++ b/internal/guidelines/guidelines.go
@@ -1,0 +1,174 @@
+package guidelines
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	dbmodel "github.com/YangKeao/haro-bot/internal/db"
+	"gorm.io/gorm"
+)
+
+// Guidelines represents the bot's core principles, personality, and behavioral rules.
+// It is loaded into the system prompt to guide the LLM's behavior.
+type Guidelines struct {
+	ID        int64
+	Content   string
+	Version   int
+	IsActive  bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Manager handles guidelines storage and retrieval
+type Manager struct {
+	db *gorm.DB
+}
+
+// NewManager creates a new guidelines manager
+func NewManager(db *gorm.DB) *Manager {
+	return &Manager{db: db}
+}
+
+// GetActive returns the currently active guidelines, or nil if none exists
+func (m *Manager) GetActive(ctx context.Context) (*Guidelines, error) {
+	var record dbmodel.Guidelines
+	err := m.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Order("version DESC").
+		First(&record).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return fromDBModel(record), nil
+}
+
+// Update creates a new version of the guidelines with the given content
+// It deactivates previous versions and returns the new guidelines
+func (m *Manager) Update(ctx context.Context, content string) (*Guidelines, error) {
+	content = trimContent(content)
+	if content == "" {
+		return nil, errors.New("guidelines content cannot be empty")
+	}
+
+	// Get current max version
+	var maxVersion int
+	var current dbmodel.Guidelines
+	err := m.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Order("version DESC").
+		First(&current).Error
+	if err == nil {
+		maxVersion = current.Version
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	// Deactivate all existing guideliness
+	if err := m.db.WithContext(ctx).
+		Model(&dbmodel.Guidelines{}).
+		Where("is_active = ?", true).
+		Update("is_active", false).Error; err != nil {
+		return nil, err
+	}
+
+	// Create new version
+	newRecord := dbmodel.Guidelines{
+		Content:  content,
+		Version:  maxVersion + 1,
+		IsActive: true,
+	}
+	if err := m.db.WithContext(ctx).Create(&newRecord).Error; err != nil {
+		return nil, err
+	}
+	return fromDBModel(newRecord), nil
+}
+
+// GetAll returns all guidelines versions, newest first
+func (m *Manager) GetAll(ctx context.Context, limit int) ([]Guidelines, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var records []dbmodel.Guidelines
+	if err := m.db.WithContext(ctx).
+		Order("version DESC").
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	result := make([]Guidelines, len(records))
+	for i, r := range records {
+		result[i] = *fromDBModel(r)
+	}
+	return result, nil
+}
+
+// GetByVersion returns a specific guidelines version
+func (m *Manager) GetByVersion(ctx context.Context, version int) (*Guidelines, error) {
+	var record dbmodel.Guidelines
+	err := m.db.WithContext(ctx).
+		Where("version = ?", version).
+		First(&record).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return fromDBModel(record), nil
+}
+
+// Rollback reactivates a previous version of the guidelines
+func (m *Manager) Rollback(ctx context.Context, version int) (*Guidelines, error) {
+	// Find the target version
+	target, err := m.GetByVersion(ctx, version)
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return nil, errors.New("guidelines version not found")
+	}
+
+	// Deactivate all
+	if err := m.db.WithContext(ctx).
+		Model(&dbmodel.Guidelines{}).
+		Where("is_active = ?", true).
+		Update("is_active", false).Error; err != nil {
+		return nil, err
+	}
+
+	// Reactivate target
+	if err := m.db.WithContext(ctx).
+		Model(&dbmodel.Guidelines{}).
+		Where("version = ?", version).
+		Update("is_active", true).Error; err != nil {
+		return nil, err
+	}
+	return m.GetByVersion(ctx, version)
+}
+
+func fromDBModel(r dbmodel.Guidelines) *Guidelines {
+	return &Guidelines{
+		ID:        r.ID,
+		Content:   r.Content,
+		Version:   r.Version,
+		IsActive:  r.IsActive,
+		CreatedAt: r.CreatedAt,
+		UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func trimContent(content string) string {
+	// Limit to ~100KB to prevent abuse
+	const maxLen = 100 * 1024
+	if len(content) > maxLen {
+		content = content[:maxLen]
+	}
+	return content
+}

--- a/internal/tools/guidelines.go
+++ b/internal/tools/guidelines.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/YangKeao/haro-bot/internal/guidelines"
+)
+
+type UpdateGuidelinesTool struct {
+	guidelinesMgr *guidelines.Manager
+}
+
+func NewUpdateGuidelinesTool(mgr *guidelines.Manager) *UpdateGuidelinesTool {
+	return &UpdateGuidelinesTool{guidelinesMgr: mgr}
+}
+
+func (t *UpdateGuidelinesTool) Name() string {
+	return "update_guidelines"
+}
+
+func (t *UpdateGuidelinesTool) Description() string {
+	return "Updates the bot's guidelines (core principles, personality, and behavioral rules). Guidelines are loaded into the system prompt and guide the LLM's behavior. Use this tool to modify how the bot behaves, its personality traits, or important rules it should follow. Changes create a new version; previous versions can be restored via rollback."
+}
+
+func (t *UpdateGuidelinesTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"content": map[string]any{
+				"type":        "string",
+				"description": "The new guidelines content. This should be a well-structured document describing the bot's personality, principles, and behavioral rules. Markdown format is recommended.",
+			},
+			"action": map[string]any{
+				"type":        "string",
+				"enum":        []string{"update", "view", "history", "rollback"},
+				"description": "The action to perform: 'update' to set new content, 'view' to see current guidelines, 'history' to list all versions, 'rollback' to restore a previous version.",
+			},
+			"version": map[string]any{
+				"type":        "integer",
+				"description": "Required for 'rollback' action: the version number to restore.",
+			},
+		},
+		"required": []string{"action"},
+	}
+}
+
+type guidelinesInput struct {
+	Action  string `json:"action"`
+	Content string `json:"content"`
+	Version int    `json:"version"`
+}
+
+func (t *UpdateGuidelinesTool) Execute(ctx context.Context, tc ToolContext, args json.RawMessage) (string, error) {
+	if t.guidelinesMgr == nil {
+		return "", fmt.Errorf("guidelines manager not available")
+	}
+
+	var input guidelinesInput
+	if err := json.Unmarshal(args, &input); err != nil {
+		return "", fmt.Errorf("parse parameters: %w", err)
+	}
+
+	var result map[string]any
+
+	switch input.Action {
+	case "view":
+		current, err := t.guidelinesMgr.GetActive(ctx)
+		if err != nil {
+			return "", fmt.Errorf("get guidelines: %w", err)
+		}
+		if current == nil {
+			result = map[string]any{
+				"message": "No guidelines are currently set. Use 'update' action to create one.",
+			}
+		} else {
+			result = map[string]any{
+				"version":  current.Version,
+				"content":  current.Content,
+				"isActive": current.IsActive,
+			}
+		}
+
+	case "update":
+		if input.Content == "" {
+			return "", fmt.Errorf("content is required for update action")
+		}
+		updated, err := t.guidelinesMgr.Update(ctx, input.Content)
+		if err != nil {
+			return "", fmt.Errorf("update guidelines: %w", err)
+		}
+		result = map[string]any{
+			"message":  fmt.Sprintf("Guidelines updated to version %d", updated.Version),
+			"version":  updated.Version,
+			"isActive": updated.IsActive,
+		}
+
+	case "history":
+		all, err := t.guidelinesMgr.GetAll(ctx, 20)
+		if err != nil {
+			return "", fmt.Errorf("get history: %w", err)
+		}
+		if len(all) == 0 {
+			result = map[string]any{
+				"message": "No guidelines history found.",
+			}
+		} else {
+			versions := make([]map[string]any, len(all))
+			for i, c := range all {
+				versions[i] = map[string]any{
+					"version":  c.Version,
+					"isActive": c.IsActive,
+					"preview":  truncatePreview(c.Content, 200),
+				}
+			}
+			result = map[string]any{
+				"versions": versions,
+			}
+		}
+
+	case "rollback":
+		if input.Version <= 0 {
+			return "", fmt.Errorf("version is required for rollback action")
+		}
+		restored, err := t.guidelinesMgr.Rollback(ctx, input.Version)
+		if err != nil {
+			return "", fmt.Errorf("rollback guidelines: %w", err)
+		}
+		result = map[string]any{
+			"message":  fmt.Sprintf("Guidelines rolled back to version %d", restored.Version),
+			"version":  restored.Version,
+			"isActive": restored.IsActive,
+		}
+
+	default:
+		return "", fmt.Errorf("unknown action: %s", input.Action)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal result: %w", err)
+	}
+	return string(data), nil
+}
+
+func truncatePreview(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}


### PR DESCRIPTION
## Summary

- Add Guidelines model and database migration (table: constitutions)
- Create GuidelinesManager for CRUD operations with versioning
- Add update_guidelines tool with actions: view, update, history, rollback
- Integrate Guidelines into system prompt via PromptBuilder
- Update Agent to accept GuidelinesManager

## Usage

Users can modify the bot's behavioral rules via the `update_guidelines` tool:

- `action: "view"` - View current guidelines
- `action: "update", content: "..."` - Update guidelines (creates new version)
- `action: "history"` - View version history
- `action: "rollback", version: N` - Rollback to version N

Guidelines are automatically loaded into the system prompt under the `## Guidelines` section.

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [ ] Manual testing with update_guidelines tool